### PR TITLE
Adding signal slots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,11 +151,21 @@ catkin_package(
 ## Build ##
 ###########
 
+include(${QT_USE_FILE})
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(include
                     ${catkin_INCLUDE_DIRS}
                     ${QT_INCLUDES})
+
+ADD_DEFINITIONS(${QT_DEFINITIONS})
+
+set(MOCS
+    include/graspit_interface.h)
+
+qt4_wrap_cpp(GENERATED_SOURCES ${MOCS})
 
 ## Declare a C++ library
 # add_library(graspit_interface
@@ -170,11 +180,13 @@ include_directories(include
 ## Declare a C++ executable
 add_library(graspit_interface
     src/graspit_interface.cpp
-    src/main.cpp)
+    src/main.cpp
+    ${GENERATED_SOURCES}
+    ${MOCS})
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above
-add_dependencies(graspit_interface ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(graspit_interface ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS} ${QT_DEFINITIONS})
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(graspit_interface

--- a/include/graspit_interface.h
+++ b/include/graspit_interface.h
@@ -47,8 +47,10 @@
 namespace GraspitInterface
 {
 
-class GraspitInterface : public Plugin
+class GraspitInterface : public QObject, public Plugin
 {
+
+    Q_OBJECT
 
 private:
   ros::NodeHandle *nh;
@@ -97,13 +99,8 @@ private:
 
   GraspPlanningState *mHandObjectState;
   SimAnnPlanner *mPlanner;
-  bool startPlanner;
-  bool plannerStarted;
-  bool buildPlannerResponse;
-  bool finishedBuildingResponse;
 
-  bool requestRender;
-
+  bool firstTimeInMainLoop;
 
   // Service callbacks
   bool getRobotCB(graspit_interface::GetRobot::Request &request,
@@ -185,11 +182,6 @@ private:
   //ActionServer callbacks
   void PlanGraspsCB(const graspit_interface::PlanGraspsGoalConstPtr &goal);
 
-  //the planner must be started in the mainloop, not the action server callback
-  void startPlannerInMainLoop();
-  void renderInMainLoop();
-  void buildPlannerResponseInMainLoop();
-
 public: 
   GraspitInterface(){}
   ~GraspitInterface(){}
@@ -197,6 +189,17 @@ public:
   virtual int init(int argc, char **argv);
 
   virtual int mainLoop();
+
+public Q_SLOTS:
+
+    void runPlannerInMainThread();
+    void processPlannerResultsInMainThread();
+
+Q_SIGNALS:
+
+    void emitRunPlannerInMainThread();
+    void emitProcessPlannerResultsInMainThread();
+
 
 };
 


### PR DESCRIPTION
1) Adding in more ros_info calls while construction planner
2) Used QSignals/QSlots to ensure that the planner is created in a thread that is able to modify the graspit world.  
