### PR TITLE
moved deletion of planner and handobjectstate

### DIFF
--- a/src/graspit_interface.cpp
+++ b/src/graspit_interface.cpp
@@ -608,9 +608,6 @@ void GraspitInterface::PlanGraspsCB(const graspit_interface::PlanGraspsGoalConst
 
     plan_grasps_as->setSucceeded(result_);
     ROS_INFO("Action ServerCB Finished");
-
-
-
 }
 
 void GraspitInterface::runPlannerInMainThread()

--- a/src/graspit_interface.cpp
+++ b/src/graspit_interface.cpp
@@ -608,23 +608,13 @@ void GraspitInterface::PlanGraspsCB(const graspit_interface::PlanGraspsGoalConst
 
     plan_grasps_as->setSucceeded(result_);
     ROS_INFO("Action ServerCB Finished");
+
+
+
 }
 
 void GraspitInterface::runPlannerInMainThread()
 {
-    ROS_INFO("Inside: runPlannerInMainLoop");
-    if(mPlanner != NULL)
-    {
-        delete mPlanner;
-        mPlanner = NULL;
-    }
-
-    if(mHandObjectState != NULL)
-    {
-        delete mHandObjectState;
-        mHandObjectState = NULL;
-    }
-
     ROS_INFO("Planner Starting in Mainloop");
     ROS_INFO("Getting Hand");
     Hand *mHand = graspitCore->getWorld()->getCurrentHand();
@@ -838,6 +828,19 @@ void GraspitInterface::runPlannerInMainThread()
     if(mPlanner->getListSize() > 0)
     {
         mPlanner->showGrasp(0);
+    }
+
+    ROS_INFO("Cleaning up mPlanner and mHandObjectState");
+    if(mHandObjectState != NULL)
+    {
+        delete mHandObjectState;
+        mHandObjectState = NULL;
+    }
+
+    if(mPlanner != NULL)
+    {
+        delete mPlanner;
+        mPlanner = NULL;
     }
 }
 


### PR DESCRIPTION
Moved to  to directly after the planner is used, this makes it harder to delete the hand before the planner is deleted which would cause a segfault
