### PR TITLE
 Changed graspit_interface ros package to work with globally installed graspit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ install:
 # fails. Running `catkin_test_results` aggregates all the results and returns
 # non-zero when a test fails (which notifies Travis the build failed).
 script:
+  - cd
   - git clone git@github.com:graspit-simulator/graspit.git
   - cd graspit
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,13 @@ env:
 ################################################################################
 
 # Install system dependencies, namely a very barebones ROS setup#.
-#before_install:
-#  - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-#  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-#  - sudo apt-get update -qq
+before_install:
+  - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+  - sudo apt-get update -qq
 
-#install:
-#  - 'ci/install.sh'
+install:
+  - 'ci/install.sh'
 
 # Compile and test (mark the build as failed if any step fails). If the
 # CATKIN_OPTIONS file exists, use it as an argument to catkin_make, for example

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,19 @@ install:
 # fails. Running `catkin_test_results` aggregates all the results and returns
 # non-zero when a test fails (which notifies Travis the build failed).
 script:
+  - git clone https://github.com/graspit-simulator/graspit
+  - cd graspit
+  - mkdir build
+  - cd build
+  - cmake ..
+  - sudo make install
+  - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
   - source /opt/ros/$ROS_DISTRO/setup.bash
   - cd
   - mkdir -p test_ws/src
   - cd test_ws/src
   - echo CI_SOURCE_PATH $CI_SOURCE_PATH
   - ln -s $CI_SOURCE_PATH graspit_interface
-  - git clone https://github.com/graspit-simulator/graspit-ros --recursive
   - catkin_init_workspace
   - cd ..
   - catkin_make

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ env:
 
 ################################################################################
 
-# Install system dependencies, namely a very barebones ROS setup.
-before_install:
-  - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-  - sudo apt-get update -qq
+# Install system dependencies, namely a very barebones ROS setup#.
+#before_install:
+#  - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+#  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+#  - sudo apt-get update -qq
 
 install:
   - 'ci/install.sh'
@@ -54,7 +54,7 @@ install:
 # non-zero when a test fails (which notifies Travis the build failed).
 script:
   - cd
-  - git clone git@github.com:graspit-simulator/graspit.git
+  - git clone https://github.com/graspit-simulator/graspit.git
   - cd graspit
   - mkdir build
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ env:
 #  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
 #  - sudo apt-get update -qq
 
-install:
-  - 'ci/install.sh'
+#install:
+#  - 'ci/install.sh'
 
 # Compile and test (mark the build as failed if any step fails). If the
 # CATKIN_OPTIONS file exists, use it as an argument to catkin_make, for example

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
 # fails. Running `catkin_test_results` aggregates all the results and returns
 # non-zero when a test fails (which notifies Travis the build failed).
 script:
-  - git clone https://github.com/graspit-simulator/graspit
+  - git clone git@github.com:graspit-simulator/graspit.git
   - cd graspit
   - mkdir build
   - cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,13 @@ find_package(catkin REQUIRED COMPONENTS
     geometry_msgs
     sensor_msgs
     roscpp
-    graspit
     actionlib
     actionlib_msgs)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 find_package(Qt4 COMPONENTS QtCore  REQUIRED)
+find_package(graspit)
 
 
 ## Uncomment this if the package has a setup.py. This macro ensures
@@ -160,6 +160,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 ## Your package locations should be listed before other locations
 include_directories(include
                     ${catkin_INCLUDE_DIRS}
+                    ${GRASPIT_INCLUDE_DIRS}
                     ${QT_INCLUDES})
 
 ADD_DEFINITIONS(${QT_DEFINITIONS})

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ To see how a client interacts with this interface, check out our python client
 GraspIt Setup:
 ------
 ```
-git clone git@github.com:graspit-simulator/graspit.git
+git clone https://github.com/graspit-simulator/graspit.git
+cd graspit
 mkdir build
 cd build
 cmake ..

--- a/README.md
+++ b/README.md
@@ -12,7 +12,23 @@ To see how a client interacts with this interface, check out our python client
 [graspit_commander](https://github.com/graspit-simulator/graspit_commander).
 
 
-Setup:
+GraspIt Setup:
+------
+```
+git clone git@github.com:graspit-simulator/graspit.git
+mkdir build
+cd build
+cmake ..
+make -j5
+sudo make install
+```
+
+You might need to add /usr/local/lib to the loaded library path as in:
+```
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+```
+
+ROS Setup:
 ------
 ```
 //create ros workspace
@@ -23,7 +39,6 @@ source /opt/ros/indigo/setup.bash
 catkin_init_workspace . 
 
 //clone packages
-git clone https://github.com/graspit-simulator/graspit-ros.git --recursive
 git clone https://github.com/graspit-simulator/graspit_interface.git
 git clone https://github.com/graspit-simulator/graspit_commander.git
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 graspit_interface
 =================
 
-This plugin exposes a ROS interface for the GraspIt! simulator via [graspit-ros](https://github.com/graspit-simulator/graspit-ros). The main purpose for writing this plugin was to demonstrate what we believe is the easiest way to expose GraspIt!
+This plugin exposes a ROS interface for the GraspIt! simulator. The main purpose for writing this plugin was to demonstrate what we believe is the easiest way to expose GraspIt!
 functionality as a variety ROS services and action servers. 
 
 Please feel free to use this as a template to write your own bridge between a ros system and GraspIt!.

--- a/include/graspit_interface.h
+++ b/include/graspit_interface.h
@@ -8,9 +8,9 @@
 #endif
 
 //GraspIt! includes
-#include <graspit_source/include/plugin.h>
-#include "graspit_source/include/EGPlanner/searchState.h"
-#include "graspit_source/include/EGPlanner/simAnnPlanner.h"
+#include <graspit/plugin.h>
+#include <graspit/EGPlanner/searchState.h>
+#include <graspit/EGPlanner/simAnnPlanner.h>
 
 //Message includes
 #include <graspit_interface/SearchSpace.h>

--- a/scripts/launch_graspit.sh
+++ b/scripts/launch_graspit.sh
@@ -5,9 +5,10 @@ if env | grep -q ^GRASPIT=
 then
     echo "Using GRASPIT=" $GRASPIT
 else
-    export GRASPIT=$(rospack find graspit)/graspit_source
+    export GRASPIT="/home/${USER}/.graspit"
+    echo "Using GRASPIT=" $GRASPIT
 fi
 
 export GRASPIT_PLUGIN_DIR=$(dirname $(catkin_find --first-only libgraspit_interface.so))
 
-rosrun graspit graspit_simulator -p libgraspit_interface --node_name graspit
+graspit_simulator -p libgraspit_interface --node_name graspit

--- a/src/graspit_interface.cpp
+++ b/src/graspit_interface.cpp
@@ -1,19 +1,20 @@
 #include "graspit_interface.h"
 
-#include "graspit_source/include/graspitCore.h"
-#include "graspit_source/include/robot.h"
-#include "graspit_source/include/world.h"
-#include "graspit_source/include/ivmgr.h"
+#include <graspit/graspitCore.h>
+#include <graspit/robot.h>
+#include <graspit/world.h>
+#include <graspit/ivmgr.h>
 
-#include "graspit_source/include/quality.h"
-#include "graspit_source/include/grasp.h"
-#include "graspit_source/include/EGPlanner/searchState.h"
-#include "graspit_source/include/EGPlanner/egPlanner.h"
-#include "graspit_source/include/EGPlanner/simAnnPlanner.h"
-#include "graspit_source/include/EGPlanner/guidedPlanner.h"
+#include <graspit/quality/quality.h>
+#include <graspit/quality/qualVolume.h>
+#include <graspit/quality/qualEpsilon.h>
+#include <graspit/grasp.h>
+#include <graspit/EGPlanner/searchState.h>
+#include <graspit/EGPlanner/egPlanner.h>
+#include <graspit/EGPlanner/simAnnPlanner.h>
+#include <graspit/EGPlanner/guidedPlanner.h>
 
-#include "cmdline/cmdline.h"
-
+#include <graspit/cmdline/cmdline.h>
 
 namespace GraspitInterface
 {


### PR DESCRIPTION
this change gets rid of dependence on graspit-ros and the need to clone graspit locally in ros workspace.

To test:
Install graspit globally as here: https://github.com/graspit-simulator/graspit/pull/120

```
//create ros workspace
mkdir -p graspit_ros_ws/src
cd graspit_ros_ws/src

source /opt/ros/indigo/setup.bash
catkin_init_workspace . 
git clone https://github.com/graspit-simulator/graspit_interface.git
//build workspace
cd graspit_ros_ws
catkin_make
```
Launching graspit_interface:
```
source devel/setup.bash
export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
roslaunch graspit_interface graspit_interface.launch
```
@mateiciocarlie @jvarley @mkghaas 