### PR TITLE
fix for qt5 / ros noetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
-find_package(Qt4 COMPONENTS QtCore  REQUIRED)
+find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
 find_package(graspit)
 
 
@@ -157,7 +157,6 @@ catkin_package(
 ## Build ##
 ###########
 
-include(${QT_USE_FILE})
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 ## Specify additional locations of header files
@@ -172,7 +171,7 @@ ADD_DEFINITIONS(${QT_DEFINITIONS})
 set(MOCS
     include/graspit_interface.h)
 
-qt4_wrap_cpp(GENERATED_SOURCES ${MOCS})
+qt5_wrap_cpp(GENERATED_SOURCES ${MOCS})
 
 ## Declare a C++ library
 # add_library(graspit_interface
@@ -200,6 +199,7 @@ add_dependencies(graspit_interface ${PROJECT_NAME}_gencpp)
 target_link_libraries(graspit_interface
   ${catkin_LIBRARIES}
   ${QT_LIBRARIES}
+  Qt5::Core Qt5::Widgets
 )
 
 #############


### PR DESCRIPTION
This change makes graspit_interface work with ros-noetic on Ubuntu 20.04