### PR TITLE
Allow collision checking before computing grasp quality to be toggled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ find_package(graspit)
    ApproachToContact.srv
    FindInitialContact.srv
    DynamicAutoGraspComplete.srv
+   GetCheckCollision.srv
+   SetCheckCollision.srv
  )
 
 

--- a/include/graspit_interface.h
+++ b/include/graspit_interface.h
@@ -46,6 +46,8 @@
 #include <graspit_interface/ApproachToContact.h>
 #include <graspit_interface/FindInitialContact.h>
 #include <graspit_interface/DynamicAutoGraspComplete.h>
+#include <graspit_interface/GetCheckCollision.h>
+#include <graspit_interface/SetCheckCollision.h>
 
 // ActionServer includes
 #include <graspit_interface/PlanGraspsAction.h>
@@ -76,6 +78,9 @@ private:
 
   ros::ServiceServer getDynamics_srv;
   ros::ServiceServer setDynamics_srv;
+
+  ros::ServiceServer getCheckCollision_srv;
+  ros::ServiceServer setCheckCollision_srv;
 
   ros::ServiceServer autoGrasp_srv;
   ros::ServiceServer autoOpen_srv;
@@ -112,6 +117,7 @@ private:
   SimAnnPlanner *mPlanner;
 
   bool firstTimeInMainLoop;
+  bool checkCollision;
 
   // Service callbacks
   bool getRobotCB(graspit_interface::GetRobot::Request &request,
@@ -200,6 +206,12 @@ private:
 
   bool dynamicAutoGraspCompleteCB(graspit_interface::DynamicAutoGraspComplete::Request &request,
                                   graspit_interface::DynamicAutoGraspComplete::Response &response);
+
+  bool getCheckCollisionCB(graspit_interface::GetCheckCollision::Request &request,
+                           graspit_interface::GetCheckCollision::Response &response);
+
+  bool setCheckCollisionCB(graspit_interface::SetCheckCollision::Request &request,
+                           graspit_interface::SetCheckCollision::Response &response);
 
   //ActionServer callbacks
   void PlanGraspsCB(const graspit_interface::PlanGraspsGoalConstPtr &goal);

--- a/srv/GetCheckCollision.srv
+++ b/srv/GetCheckCollision.srv
@@ -1,0 +1,3 @@
+
+---
+bool collisionCheckEnabled

--- a/srv/SetCheckCollision.srv
+++ b/srv/SetCheckCollision.srv
@@ -1,0 +1,2 @@
+bool enableCollisionCheck
+---


### PR DESCRIPTION
There are cases where the grasp quality must be computed even when there is an apparent collision (e.g. imprecise reconstruction of a 3D scene). This commit adds two services, getCheckCollision and setCheckCollision, that allows the controlling node to get and toggle whether collision check is to be performed prior to computing the grasp quality metrics. To be in line with current conventions, collision checking is enabled by default.